### PR TITLE
Round values before change precision

### DIFF
--- a/lib/assets/utils/toProcessable.js
+++ b/lib/assets/utils/toProcessable.js
@@ -20,7 +20,8 @@ const toProcessable = (
   tokenSymbol: TokenSymbol = "ETH-T",
 ): BigNumber => {
   const precision: number = getDecimals(tokenSymbol);
-  return new BigNumber(quantity).times(10 ** precision);
+  const roundedQuantity = quantity.round(precision);
+  return new BigNumber(roundedQuantity).times(10 ** precision);
 };
 
 export default toProcessable;


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

toProcessable: Round quantities before changing the precision. Numbers with more decimals than precision would create a BigNumber with decimals which are not encoded in ParityJS. (In web3 the encoding takes care of removing decimals in BigNumbers) 

### Deprecated

### Removed

### Fixed

### Security
