### PR TITLE
Update transferTo.js

### DIFF
--- a/lib/assets/transactions/transferTo.js
+++ b/lib/assets/transactions/transferTo.js
@@ -28,7 +28,7 @@ const transferTo = async (
   const args = [toAddress, toProcessable(quantity, symbol)];
   const receipt = await sendTransaction(
     tokenContract,
-    "tranfer",
+    "transfer",
     args,
     {},
     from,


### PR DESCRIPTION
Replace tranfer with transfer.

Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

transferTo: Fix method call name. It should be transfer instead of tranfer.

### Deprecated

### Removed

### Fixed

### Security
