### PR TITLE
Use timeout in makeOrderFromAccount

### DIFF
--- a/lib/exchange/transactions/makeOrderFromAccount.js
+++ b/lib/exchange/transactions/makeOrderFromAccount.js
@@ -43,7 +43,7 @@ const makeOrderFromAccount = async ({
     `Approve took longer that 30 seconds. ${sellHowMuch.toString()} ${sellSymbol} ${
       simpleMarketContract.address
     }`,
-    30 * 1000,
+    timeout,
   );
 
   const args = [


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

makeOrderFromAccount: The function takes timeout as a parameter but it is never used on the rush function.

### Deprecated

### Removed

### Fixed

### Security
