### PR TITLE
Wallet as first argument

### DIFF
--- a/lib/exchange/transactions/makeOrderFromAccount.js
+++ b/lib/exchange/transactions/makeOrderFromAccount.js
@@ -23,13 +23,15 @@ type Argument = Order & {
  * @param argument.from from account
  * @param argument.timeout wait time for the transaction
  */
-const makeOrderFromAccount = async ({
+const makeOrderFromAccount = async (
   wallet,
-  sell: { howMuch: sellHowMuch, symbol: sellSymbol },
-  buy: { howMuch: buyHowMuch, symbol: buySymbol },
-  from = setup.defaultAccount,
-  timeout = 30 * 1000,
-}: Argument): Promise<Order> => {
+  {
+    sell: { howMuch: sellHowMuch, symbol: sellSymbol },
+    buy: { howMuch: buyHowMuch, symbol: buySymbol },
+    from = setup.defaultAccount,
+    timeout = 30 * 1000,
+  }: Argument,
+): Promise<Order> => {
   const simpleMarketContract = await getSimpleMarketContract();
   const approvePromise = approve(
     wallet,


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

makeOrderFromAccount: Wallet is passed as one of the parameters in the order obj instead of being the first parameter, so that, instead of func(wallet, order) it is doing func({wallet, ...order})

### Deprecated

### Removed

### Fixed

### Security
