### PR TITLE
Get token info from contracts

### DIFF
--- a/lib/assets/utils/getAddress.js
+++ b/lib/assets/utils/getAddress.js
@@ -7,7 +7,9 @@ import type { TokenSymbol } from "../schemas/TokenSymbol";
 /**
  * Gets address of given `tokenSymbol`
  */
-const getAddress = (tokenSymbol: TokenSymbol): Address =>
-  getTokenInfo(tokenSymbol).address.toLowerCase();
+const getAddress = async (tokenSymbol: TokenSymbol): Address => {
+  const token = await getTokenInfo(tokenSymbol);
+  return token.address.toLowerCase();
+};
 
 export default getAddress;

--- a/lib/assets/utils/getDecimals.js
+++ b/lib/assets/utils/getDecimals.js
@@ -6,7 +6,9 @@ import type { TokenSymbol } from "../schemas/TokenSymbol";
 /**
  * Gets decimals of given `tokenSymbol`
  */
-const getDecimals = (tokenSymbol: TokenSymbol): number =>
-  getTokenInfo(tokenSymbol).decimals;
+const getDecimals = async (tokenSymbol: TokenSymbol): number => {
+  const token = await getTokenInfo(tokenSymbol);
+  return token.decimal;
+};
 
 export default getDecimals;

--- a/lib/assets/utils/getSymbol.js
+++ b/lib/assets/utils/getSymbol.js
@@ -1,21 +1,31 @@
 // @flow
 import tokenInfo from "./tokenInfo";
 
+import getConfig from "../../version/calls/getConfig";
+
 import type { Address } from "../schemas/Address";
 import type { TokenSymbol } from "../schemas/TokenSymbol";
 
-const getTokenInfoByAddress = (address: string): any =>
-  tokenInfo.kovan.find(
-    t => t.address.toLowerCase() === address.toLowerCase(),
-  ) ||
-  (() => {
-    throw new Error(`No token found with address ${address}`);
-  })();
+const getTokenInfoByAddress = async (address: string): any => {
+  address = address.toLowerCase();
+
+  const config = await getConfig();
+
+  for (const asset of config.assets) {
+    if (asset.address.toLowerCase() == address) {
+      return asset;
+    }
+  }
+
+  throw Error(`No token found with address ${address}`);
+};
 
 /**
  * Gets the token symbol by its ERC20 `address`
  */
-const getSymbol = (address: Address): TokenSymbol =>
-  getTokenInfoByAddress(address).symbol;
+const getSymbol = async (address: Address): TokenSymbol => {
+  const token = await getTokenInfoByAddress(address);
+  return token.name;
+};
 
 export default getSymbol;

--- a/lib/assets/utils/getTokenInfo.js
+++ b/lib/assets/utils/getTokenInfo.js
@@ -1,15 +1,25 @@
 // @flow
 import tokenInfo from "./tokenInfo";
 
+import getConfig from "../../version/calls/getConfig";
+
 /**
  * Gets the token info by `tokenSymbol`
  * @deprecated Should get token info directly form AssetRegistrar
  * @throws If no token with given symbol is registered
  */
-const getTokenInfo = (tokenSymbol: string): any =>
-  tokenInfo.kovan.find(t => t.symbol === tokenSymbol.toUpperCase()) ||
-  (() => {
-    throw new Error(`No token found with symbol ${tokenSymbol}`);
-  })();
+const getTokenInfo = async (tokenSymbol: string): any => {
+  tokenSymbol = tokenSymbol.toUpperCase();
+
+  const config = await getConfig();
+
+  for (const asset of config.assets) {
+    if (asset.name == tokenSymbol) {
+      return asset;
+    }
+  }
+
+  throw Error(`No token found with symbol ${tokenSymbol}`);
+};
 
 export default getTokenInfo;


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

- getTokenInfo: Get token info from the contracts instead of using static conf files.
- getAddress: Use new getTokenInfo function.
- getDecimals: Use new getTokenInfo function.
- getSymbol: Use new getTokenInfo function.

### Deprecated

### Removed

### Fixed

Fix #79 

### Security
