### PR TITLE
Connect to local node if possible @melonproject/ipfs-frontend#134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ### Changed
 
+* Breaking: getParityProvider is now async and tries to connect to local node first
+
+## [0.6.37]
+
+### Changed
+
 * Use new datafeed.hasRecentPrice in onBlock instead of isValid
 * walkLib ' instead of "
 

--- a/lib/utils/parity/getParityProvider.js
+++ b/lib/utils/parity/getParityProvider.js
@@ -1,34 +1,48 @@
 import Api from '@parity/api';
 import providers from '../constants/providers';
 
-const checkHttpProvider = (url, connectionTimeout) => {
-  const provider = new Api.Provider.Http(url, connectionTimeout);
-  return provider._connected ? provider : null;
+const providerTypeUrlMap = {
+  [providers.PARITY]: 'http://localhost:8545',
+  [providers.HOSTED]: 'https://kovan.melonport.com',
 };
 
-const getParityProvider = (connectionTimeout = 1000) => {
-  // TODO: First check for the local provider + async?
-  let httpProvider = checkHttpProvider(
-    'https://kovan.melonport.com',
-    connectionTimeout,
-  );
-  let providerType;
-
-  if (httpProvider) {
-    providerType = providers.LOCAL;
-  } else {
-    httpProvider = checkHttpProvider(
-      'http://localhost:8545',
-      connectionTimeout,
-    );
-    if (httpProvider) {
-      providerType = providers.HOSTED;
-    } else {
-      providerType = providers.NONE;
-    }
+const checkHttpProvider = async (url, connectionTimeout) => {
+  try {
+    const provider = new Api.Provider.Http(url, connectionTimeout);
+    const api = new Api(provider);
+    // HACK: Parity does not properly return api.isConnected. This is always true.
+    // So we need to explicitly make a call that fails for a unreachable node. :(
+    await api.net.version();
+    return { api, provider };
+  } catch (e) {
+    return false;
   }
-  const api = new Api(httpProvider);
-  return { provider: httpProvider, providerType, api };
+};
+
+/**
+ * Walks through providerTypUrlMap from top to bottom and returns the first
+ * provider that successfully connects.
+ *
+ * @returns Object {
+ *  api: [Parity API instance],
+ *  provider: [Parity Provider Instance],
+ *  providerType: [f.e. providers.Parity],
+ * }
+ */
+const getParityProvider = async connectionTimeout => {
+  const provider = Object.entries(providerTypeUrlMap).reduce(
+    async (lastPromise, [type, url]) => {
+      const lastType = await lastPromise;
+
+      if (lastType) return lastType;
+
+      const candidate = await checkHttpProvider(url, connectionTimeout);
+      return candidate ? { ...candidate, providerType: type } : false;
+    },
+    new Promise(resolve => resolve(false)),
+  );
+
+  return provider || { providerType: providers.NONE };
 };
 
 export default getParityProvider;


### PR DESCRIPTION
### Changed

* Breaking: getParityProvider is now async and tries to connect to local node first